### PR TITLE
Removing unused private fields

### DIFF
--- a/app/src/main/java/com/architjn/acjmusicplayer/service/PlayerService.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/service/PlayerService.java
@@ -37,10 +37,8 @@ public class PlayerService extends Service {
     public static final String ACTION_PREV_SONG = "ACTION_PREV_SONG";
     public static final String ACTION_PAUSE_SONG = "ACTION_PAUSE_SONG";
     public static final String ACTION_ADD_QUEUE = "ACTION_ADD_QUEUE";
-    private static final String TAG = "PlayerService-TAG";
     private PlayerHandler musicPlayerHandler;
     private Context context;
-    private ListType listType;
     private NotificationHandler notificationHandler;
     private BroadcastReceiver playerServiceBroadcastReceiver = new BroadcastReceiver() {
         @Override

--- a/app/src/main/java/com/architjn/acjmusicplayer/task/PlayerLoader.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/task/PlayerLoader.java
@@ -31,7 +31,6 @@ import java.io.File;
  */
 public abstract class PlayerLoader {
 
-    private static final String TAG = "PlayerLoader-TAG";
     private Context context;
     private ImageView img;
     private String path;

--- a/app/src/main/java/com/architjn/acjmusicplayer/ui/layouts/activity/AlbumActivity.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/ui/layouts/activity/AlbumActivity.java
@@ -34,7 +34,6 @@ import java.io.File;
  */
 public class AlbumActivity extends AppCompatActivity {
 
-    private static final String TAG = "AlbumActivity-TAG";
     private RecyclerView rv;
     private ImageView albumArt;
     private PermissionChecker permissionChecker;

--- a/app/src/main/java/com/architjn/acjmusicplayer/ui/layouts/activity/ArtistActivity.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/ui/layouts/activity/ArtistActivity.java
@@ -24,7 +24,6 @@ import com.architjn.acjmusicplayer.utils.adapters.ArtistSubListAdapter;
  */
 public class ArtistActivity extends AppCompatActivity {
 
-    private static final String TAG = "ArtistActivity-TAG";
     private RecyclerView rv;
 
     @Override

--- a/app/src/main/java/com/architjn/acjmusicplayer/ui/layouts/activity/MainActivity.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/ui/layouts/activity/MainActivity.java
@@ -46,7 +46,6 @@ import io.fabric.sdk.android.Fabric;
  */
 public class MainActivity extends AppCompatActivity {
 
-    private static final String TAG = "MainActivity-TAG";
     private FragmentName currentFragment;
     private DrawerLayout drawerLayout;
     private Toolbar toolbar;

--- a/app/src/main/java/com/architjn/acjmusicplayer/ui/layouts/activity/PlaylistActivity.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/ui/layouts/activity/PlaylistActivity.java
@@ -19,7 +19,6 @@ import com.architjn.acjmusicplayer.utils.adapters.PlaylistSongListAdapter;
  */
 public class PlaylistActivity extends AppCompatActivity {
 
-    private static final String TAG = "PlaylistActivity-TAG";
     private RecyclerView rv;
 
     @Override

--- a/app/src/main/java/com/architjn/acjmusicplayer/ui/layouts/fragments/AlbumsListFragment.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/ui/layouts/fragments/AlbumsListFragment.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
  */
 public class AlbumsListFragment extends Fragment {
 
-    private static final String TAG = "AlbumsListFragment-TAG";
     private Context context;
     private View mainView;
     private RecyclerView gv;

--- a/app/src/main/java/com/architjn/acjmusicplayer/ui/layouts/fragments/SearchViewFragment.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/ui/layouts/fragments/SearchViewFragment.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
  */
 public class SearchViewFragment extends Fragment {
 
-    private static final String TAG = "SearchViewFragment-TAG";
     private SearchView searchView;
     private RecyclerView rv;
     private Context context;

--- a/app/src/main/java/com/architjn/acjmusicplayer/ui/widget/PointShiftingArrayList.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/ui/widget/PointShiftingArrayList.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 
 public class PointShiftingArrayList<T> extends ArrayList<T> {
 
-    private static final String TAG = "PointShiftingArrayList-TAG";
     private int pointOnShifted = 0;
 
     @Override

--- a/app/src/main/java/com/architjn/acjmusicplayer/ui/widget/slidinguppanel/SlidingUpPanelLayout.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/ui/widget/slidinguppanel/SlidingUpPanelLayout.java
@@ -25,7 +25,6 @@ import com.architjn.acjmusicplayer.R;
 
 public class SlidingUpPanelLayout extends ViewGroup {
 
-    private static final String TAG = SlidingUpPanelLayout.class.getSimpleName();
 
     /**
      * Default peeking out panel height

--- a/app/src/main/java/com/architjn/acjmusicplayer/ui/widget/slidinguppanel/ViewDragHelper.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/ui/widget/slidinguppanel/ViewDragHelper.java
@@ -37,7 +37,6 @@ import java.util.Arrays;
  * views within their parent ViewGroup.
  */
 public class ViewDragHelper {
-    private static final String TAG = "ViewDragHelper";
 
     /**
      * A null/invalid pointer ID.

--- a/app/src/main/java/com/architjn/acjmusicplayer/utils/ListSongs.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/utils/ListSongs.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
  */
 public class ListSongs {
 
-    private static final String TAG = "ListSongs-TAG";
 
     public static ArrayList<Album> getAlbumList(Context context) {
         final ArrayList<Album> albumList = new ArrayList<>();

--- a/app/src/main/java/com/architjn/acjmusicplayer/utils/adapters/ArtistSubListAdapter.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/utils/adapters/ArtistSubListAdapter.java
@@ -30,7 +30,6 @@ import java.util.ArrayList;
  */
 public class ArtistSubListAdapter extends RecyclerView.Adapter<ArtistSubListAdapter.SimpleItemViewHolder> {
 
-    private static final String TAG = "ArtistSubListAdapter-TAG";
     private ArrayList<Album> items;
     private Context context;
 

--- a/app/src/main/java/com/architjn/acjmusicplayer/utils/adapters/ArtistsListAdapter.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/utils/adapters/ArtistsListAdapter.java
@@ -39,7 +39,6 @@ import java.util.ArrayList;
  */
 public class ArtistsListAdapter extends RecyclerView.Adapter<ArtistsListAdapter.SimpleItemViewHolder> {
 
-    private static final String TAG = "ArtistsListAdapter-TAG";
     private ArrayList<Artist> items;
     private ArtistListFragment fragment;
     private Context context;

--- a/app/src/main/java/com/architjn/acjmusicplayer/utils/adapters/PlayingListAdapter.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/utils/adapters/PlayingListAdapter.java
@@ -29,7 +29,6 @@ public class PlayingListAdapter extends RecyclerView.Adapter<PlayingListAdapter.
     private static final int ITEM_VIEW_TYPE_HEADER = 0;
     private static final int ITEM_VIEW_TYPE_ITEM = 1;
     private static final int ITEM_VIEW_TYPE_UP_NEXT_HEADER = 2;
-    private static final String TAG = "PlayingListAdapter-TAG";
 
     private PointShiftingArrayList<Song> items;
     private Context context;

--- a/app/src/main/java/com/architjn/acjmusicplayer/utils/adapters/PlaylistListAdapter.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/utils/adapters/PlaylistListAdapter.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
  */
 public class PlaylistListAdapter extends RecyclerView.Adapter<PlaylistListAdapter.SimpleItemViewHolder> {
 
-    private static final String TAG = "PlaylistListAdapter-TAG";
     private ArrayList<Playlist> items;
     private PlaylistListFragment fragment;
     private Context context;

--- a/app/src/main/java/com/architjn/acjmusicplayer/utils/adapters/SearchListAdapter.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/utils/adapters/SearchListAdapter.java
@@ -44,7 +44,6 @@ public class SearchListAdapter extends RecyclerView.Adapter<SearchListAdapter.Si
     public static final int ITEM_VIEW_TYPE_LIST_ARTIST = 3;
     public static final int ITEM_VIEW_TYPE_LIST_ALBUM = 4;
     public static final int ITEM_VIEW_TYPE_LIST_SONG = 5;
-    private static final String TAG = "SearchListAdapter-TAG";
     private ArrayList<Song> songs;
     private ArrayList<Album> albums;
     private ArrayList<Artist> artists;

--- a/app/src/main/java/com/architjn/acjmusicplayer/utils/handlers/ArtistImgHandler.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/utils/handlers/ArtistImgHandler.java
@@ -17,7 +17,6 @@ import java.util.Collections;
  */
 public abstract class ArtistImgHandler extends SQLiteOpenHelper {
 
-    private static final String TAG = "ArtistImgHandler-TAG";
     private static final int DATABASE_VERSION = 1;
     private static final String DATABASE_NAME = "ArtistDB";
     private static final String TABLE_PLAYBACK = "artist";

--- a/app/src/main/java/com/architjn/acjmusicplayer/utils/handlers/NotificationHandler.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/utils/handlers/NotificationHandler.java
@@ -26,7 +26,6 @@ import java.io.File;
 public class NotificationHandler {
 
     private static final int NOTIFICATION_ID = 272448;
-    private static final String TAG = "NotificationHandler-TAG";
     private Context context;
     private PlayerService service;
     private boolean notificationActive;

--- a/app/src/main/java/com/architjn/acjmusicplayer/utils/handlers/PlayerDBHandler.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/utils/handlers/PlayerDBHandler.java
@@ -27,7 +27,6 @@ public class PlayerDBHandler extends SQLiteOpenHelper {
     public static final String SONG_KEY_ID = "song_id";
     public static final String SONG_KEY_REAL_ID = "song_real_id";
     public static final String SONG_KEY_LAST_PLAYED = "song_last_played";
-    private static final String TAG = "PlayerDBHandler-TAG";
     private Context context;
     private int fetchedPlayingPos = -1;
 

--- a/app/src/main/java/com/architjn/acjmusicplayer/utils/handlers/PlayerHandler.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/utils/handlers/PlayerHandler.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
  */
 public class PlayerHandler {
 
-    private static final String TAG = "PlayerHandler-TAG";
     private final PlayerDBHandler dbHandler;
     private final UserPreferenceHandler preferenceHandler;
     private Context context;

--- a/app/src/main/java/com/architjn/acjmusicplayer/utils/handlers/PlaylistDBHelper.java
+++ b/app/src/main/java/com/architjn/acjmusicplayer/utils/handlers/PlaylistDBHelper.java
@@ -30,7 +30,6 @@ public class PlaylistDBHelper extends SQLiteOpenHelper {
 
     private static final String PLAYLIST_KEY_ID = "playlist_id";
     private static final String PLAYLIST_KEY_NAME = "playlist_name";
-    private static final String TAG = "PlaylistDBHelper-TAG";
 
     private Context context;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1068 - “ Unused private fields should be removed”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1068
Please let me know if you have any questions.
Ayman Abdelghany
